### PR TITLE
travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: generic
+install: true
+addons:
+  apt:
+    packages:
+    - python-pyicu
+script: en-cs/test.sh

--- a/en-cs/sort.sh
+++ b/en-cs/sort.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
+set -o nounset
+set -o errexit
+
+dict_file="en-cs.txt"
+tmp_file="sort.tmp"
 
 cd `dirname $0`
-LC_COLLATE=cs_CZ.utf8 sort -f -o tmp.sort en-cs.txt
-mv tmp.sort en-cs.txt
+
+./sort.py < $dict_file > $tmp_file
+mv $tmp_file $dict_file

--- a/en-cs/test.sh
+++ b/en-cs/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+cd `dirname $0`
+
+./sort.sh
+git diff --exit-code
+
+# TODO: doplnit kontrolu formatu


### PR DESCRIPTION
Základ pro https://github.com/xHire/svobodneslovniky/issues/5.

Po začlenění stačí zapnout testování na [travis-ci.org](https://travis-ci.org).