### PR TITLE
A base for multiple-column unicode-aware sort

### DIFF
--- a/en-cs/sort.py
+++ b/en-cs/sort.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import icu
+import sys
+
+column_count = 5
+line_number = 0
+entries = []
+
+for line in sys.stdin:
+    line_number += 1
+    entry = line.rstrip('\n').split('\t')
+    if len(entry) != column_count:
+        raise RuntimeError('Format error on line {}: "{}"'.format(line_number, line))
+    entries.append(entry)
+
+cs_sort_key = icu.Collator.createInstance(icu.Locale('cs_CZ.UTF-8')).getSortKey
+en_sort_key = icu.Collator.createInstance(icu.Locale('en_US.UTF-8')).getSortKey
+
+def sort_key(entry):
+    return (
+        en_sort_key(entry[0]),
+        cs_sort_key(entry[1]),
+        cs_sort_key(entry[2]),
+        cs_sort_key(entry[3]),
+        cs_sort_key(entry[4]))
+
+entries.sort(key=sort_key)
+
+for entry in entries:
+    print('\t'.join(entry))


### PR DESCRIPTION
Základ nového řadícího scriptu. Bere v potaz sloupce a unicode znaky. První sloupec řadí podle anglických pravidel, zbylé podle českých.

Čte ze `stdin` a zapisuje na `stdout`:

```sh
./sort.py < en-cs.txt > en-cs.sorted.txt
```

Vyžaduje Python a python-icu.